### PR TITLE
ci(riscv64): add native build workflow for linux/riscv64

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+  labels:
+    - ubuntu-24.04-riscv

--- a/.github/workflows/build-riscv64.yml
+++ b/.github/workflows/build-riscv64.yml
@@ -1,0 +1,212 @@
+#
+# Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.  Oracle designates this
+# particular file as subject to the "Classpath" exception as provided
+# by Oracle in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
+---
+name: Build riscv64
+
+"on":
+  push:
+    tags:
+      - 'jvmci-*'
+  workflow_dispatch:
+    inputs:
+      jvmci_tag:
+        description: 'JVMCI release tag to build (e.g. jvmci-25.1-b17)'
+        required: true
+
+jobs:
+  build-riscv64:
+    name: Build labs-openjdk for linux/riscv64
+    runs-on: ubuntu-24.04-riscv
+    timeout-minutes: 300
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Determine version strings
+        id: ver
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VER_FILE=make/conf/version-numbers.conf
+          FEATURE=$(grep '^DEFAULT_VERSION_FEATURE=' "$VER_FILE" | cut -d= -f2)
+          INTERIM=$(grep '^DEFAULT_VERSION_INTERIM=' "$VER_FILE" | cut -d= -f2)
+          UPDATE=$(grep '^DEFAULT_VERSION_UPDATE=' "$VER_FILE" | cut -d= -f2)
+          TAG="${{ inputs.jvmci_tag || github.ref_name }}"
+          if ! printf '%s' "$TAG" | grep -Eq '^jvmci-[0-9]+(\.[0-9]+)*-b[0-9]+$'; then
+            echo "ERROR: expected a JVMCI release tag (e.g. jvmci-25.1-b17), got: $TAG" >&2
+            exit 1
+          fi
+
+          JDK_VERSION="${FEATURE}.${INTERIM}.${UPDATE}"
+
+          # Derive the JDK build number (+NN) from the upstream aarch64 artifact
+          # for the same jvmci tag.  This keeps our artifact name in sync with
+          # what mx's suite.py expects (e.g. labsjdk-ce-25.0.2+10-jvmci-25.1-b17-...).
+          BUILD=$(gh api "repos/graalvm/labs-openjdk/releases/tags/${TAG}" \
+            --jq '[.assets[] | select(.name | test("linux-aarch64\\.tar\\.gz$")) | .name] | first' \
+            2>/dev/null \
+            | sed -n 's/.*+\([0-9][0-9]*\)-.*/\1/p')
+          if [ -z "$BUILD" ]; then
+            echo "ERROR: could not resolve build number from upstream aarch64 asset for ${TAG}" >&2
+            exit 1
+          fi
+
+          STAGING="labsjdk-ce-${JDK_VERSION}-${TAG}"
+          TARBALL="labsjdk-ce-${JDK_VERSION}+${BUILD}-${TAG}-linux-riscv64.tar.gz"
+
+          echo "feature=${FEATURE}"         >> "$GITHUB_OUTPUT"
+          echo "jdk_version=${JDK_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "build=${BUILD}"             >> "$GITHUB_OUTPUT"
+          echo "tag=${TAG}"                 >> "$GITHUB_OUTPUT"
+          echo "staging=${STAGING}"         >> "$GITHUB_OUTPUT"
+          echo "tarball=${TARBALL}"         >> "$GITHUB_OUTPUT"
+
+      - name: Install build prerequisites
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y \
+            autoconf make gcc g++ \
+            libx11-dev libxext-dev libxrender-dev libxtst-dev libxt-dev \
+            libxrandr-dev \
+            libcups2-dev libfontconfig1-dev \
+            libasound2-dev libfreetype-dev \
+            zip unzip
+
+      - name: Install boot JDK
+        run: |
+          VER_FILE=make/conf/version-numbers.conf
+          # "24 25" → try highest version first
+          ACCEPTABLE=$(grep '^DEFAULT_ACCEPTABLE_BOOT_VERSIONS=' "$VER_FILE" \
+            | cut -d'"' -f2 | tr ' ' '\n' | sort -rn)
+
+          BOOT_DIR=/opt/boot-jdk
+          mkdir -p "$BOOT_DIR"
+
+          # Strategy 1: Temurin for each acceptable version (highest first)
+          for VER in $ACCEPTABLE; do
+            ASSET_URL=$(curl -sf \
+              "https://api.adoptium.net/v3/assets/latest/${VER}/hotspot?architecture=riscv64&image_type=jdk&jvm_impl=hotspot&os=linux&vendor=eclipse" \
+              | grep -o '"link":"[^"]*"' | head -1 | cut -d'"' -f4)
+            if [ -n "$ASSET_URL" ]; then
+              echo "Fetching Temurin JDK ${VER} riscv64..."
+              curl -sL "$ASSET_URL" | tar -xz -C "$BOOT_DIR" --strip-components=1
+              break
+            fi
+          done
+
+          # Strategy 2: latest riscv64 artifact published in this repo
+          if [ ! -x "$BOOT_DIR/bin/java" ]; then
+            echo "Temurin not available, checking repo releases..."
+            ASSET_URL=$(gh api "repos/${{ github.repository }}/releases" \
+              --jq '[.[].assets[] | select(.name | test("linux-riscv64\\.tar\\.gz$"))] | sort_by(.updated_at) | last | .browser_download_url' \
+              2>/dev/null || true)
+            if [ -n "$ASSET_URL" ] && [ "$ASSET_URL" != "null" ]; then
+              echo "Fetching boot JDK from repo releases..."
+              curl -sL "$ASSET_URL" | tar -xz -C "$BOOT_DIR" --strip-components=1
+            fi
+          fi
+
+          if [ ! -x "$BOOT_DIR/bin/java" ]; then
+            echo "ERROR: No suitable boot JDK found for riscv64." >&2
+            echo "Acceptable versions: $ACCEPTABLE" >&2
+            exit 1
+          fi
+
+          echo "JAVA_HOME=$BOOT_DIR" >> "$GITHUB_ENV"
+          echo "$BOOT_DIR/bin"       >> "$GITHUB_PATH"
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Verify boot JDK
+        run: java -version
+
+      - name: Configure
+        env:
+          VERSION_BUILD: ${{ steps.ver.outputs.build }}
+          VERSION_OPT: ${{ steps.ver.outputs.tag }}
+        run: |
+          bash configure \
+            --with-jvm-features=jvmci \
+            --with-jvm-variants=server \
+            --disable-warnings-as-errors \
+            --with-extra-cflags="-fcommon" \
+            --with-boot-jdk="$JAVA_HOME" \
+            --with-version-build="$VERSION_BUILD" \
+            --with-version-opt="$VERSION_OPT"
+
+      - name: Build images and static-libs
+        run: time make images static-libs-image JOBS=$(nproc)
+
+      - name: Package artifact
+        env:
+          STAGING: ${{ steps.ver.outputs.staging }}
+          TARBALL: ${{ steps.ver.outputs.tarball }}
+        run: |
+          BUILD_DIR=$(ls -d build/linux-riscv64-*-release/images 2>/dev/null | head -1)
+          if [ -z "$BUILD_DIR" ]; then
+            echo "ERROR: could not find build output directory" >&2
+            exit 1
+          fi
+
+          cp -a "$BUILD_DIR/jdk" "$STAGING"
+          mkdir -p "$STAGING/lib/static/linux-riscv64/glibc"
+          # Copy all .a files recursively, flattening into glibc/ (server/libjvm.a → glibc/libjvm.a)
+          find "$BUILD_DIR/static-libs/lib" -name '*.a' \
+            -exec cp {} "$STAGING/lib/static/linux-riscv64/glibc/" \;
+
+          tar -czf "$TARBALL" "$STAGING/"
+          sha1sum "$TARBALL" | awk '{print $1}' > "${TARBALL}.sha1"
+          ls -lh "$TARBALL" "${TARBALL}.sha1"
+          echo "Static libs:"
+          tar -tzf "$TARBALL" | grep "static/" | head -10
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: labsjdk-riscv64
+          path: |
+            *.tar.gz
+            *.tar.gz.sha1
+          retention-days: 90
+
+      - name: Publish release
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          TARBALL: ${{ steps.ver.outputs.tarball }}
+          TAG: ${{ steps.ver.outputs.tag }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if gh release view "$TAG" &>/dev/null; then
+            gh release upload "$TAG" "$TARBALL" "${TARBALL}.sha1" --clobber
+          else
+            gh release create "$TAG" \
+              --title "$TAG" \
+              --notes "riscv64 build of labs-openjdk at tag ${TAG}" \
+              "$TARBALL" "${TARBALL}.sha1"
+          fi

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,5 @@
+---
+extends: relaxed
+rules:
+  line-length:
+    max: 200


### PR DESCRIPTION
## What this adds

A GitHub Actions workflow (`.github/workflows/build-riscv64.yml`) that builds labs-openjdk for `linux/riscv64` on a native riscv64 runner provided by the RISE project.

## Why

`mx fetch-jdk labsjdk-ce-latest` on riscv64 already knows the expected URL pattern:

```
https://github.com/graalvm/labs-openjdk/releases/download/jvmci-25.1-b17/labsjdk-ce-25.0.2+10-jvmci-25.1-b17-linux-riscv64.tar.gz
```

That URL 404s. The missing artifact blocks GraalVM native-image on riscv64 because `JvmFuncsFallbacksBuildTask` needs the static `.a` libraries that only labs-openjdk provides (`lib/static/linux-riscv64/glibc/lib*.a`).

Closes #33

## What the workflow does

- Triggers on `jvmci-*` tag pushes and `workflow_dispatch` (with a tag input for manual runs)
- Queries the upstream aarch64 release to derive the `+NN` build number, so the artifact name matches what `mx`/`suite.py` expects
- Installs a boot JDK via Adoptium Temurin riscv64, with a fallback to the most recent riscv64 artifact published in this repo
- Builds `images` and `static-libs-image` — the static libraries are what downstream GraalVM actually needs
- Packages as `labsjdk-ce-<version>+<build>-<tag>-linux-riscv64.tar.gz` with a `.sha1` sidecar
- On tag pushes: creates or updates the GitHub release with the artifact
- On all runs: uploads as a workflow artifact (90-day retention)

## Build time

Two CI test runs on a RISE riscv64 runner completed in 214 and 219 minutes (roughly 3.5–3.7 hours each). That matches what you'd expect building OpenJDK from source natively.

Cross-compiling for riscv64 via QEMU works, but runs slowly. The OpenJDK build executes Java tools (`javac`, `jimage`, intermediate launchers) throughout configure and make, so every one of those invocations gets QEMU overhead on top. For reference, a Python C extension that takes 3.5 minutes on a native RISE runner takes 38 minutes under QEMU, roughly 10x. For a multi-hour JDK build, where more of the work is Java rather than C compilation, the hit is worse. We haven't measured it end-to-end under emulation, but easily over 10 hours seems likely.

## Runner

The workflow uses `ubuntu-24.04-riscv`, provided by the [RISE project](https://riseproject.dev) (RISC-V Software Ecosystem). RISE operates a pool of native riscv64 GitHub Actions runners and makes them available to open-source repos at no cost. To use them here, the `graalvm` org needs to be enrolled in the RISE runner program; the RISE team handles that (contact via https://riseproject.dev or their Slack). If the label isn't accessible yet, `runs-on` can be pointed at a QEMU-based alternative while enrollment is in progress.

The workflow was validated on a fork ([gounthar/labs-openjdk](https://github.com/gounthar/labs-openjdk)) with the RISE runner already enabled.

## Related

This is part of a broader effort to enable GraalVM native-image on riscv64 (oracle/graal#13351). The static library artifact produced here unblocks the `JvmFuncsFallbacksBuildTask` step in the GraalVM build.